### PR TITLE
Potential fix for code scanning alert no. 10: Use of password hash with insufficient computational effort

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "discord.js": "^14.14.1",
     "dotenv": "^16.3.1",
     "openai": "^4.53.0",
-    "sanitize-html": "^2.17.0"
+    "sanitize-html": "^2.17.0",
+    "bcrypt": "^6.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/src/security/auth-manager.ts
+++ b/src/security/auth-manager.ts
@@ -6,6 +6,7 @@
  */
 
 import { createHash, randomBytes, createHmac } from 'crypto';
+import * as bcrypt from 'bcrypt';
 import { logger } from '../utils/logger.js';
 import { securityAuditLogger, SecurityEventType } from './audit-logger.js';
 
@@ -618,7 +619,9 @@ export class AuthenticationManager {
   }
 
   private hashApiKey(key: string): string {
-    return createHash('sha256').update(key + this.JWT_SECRET).digest('hex');
+    // Use bcrypt with a cost factor of 12 (industry standard)
+    const salt = bcrypt.genSaltSync(12);
+    return bcrypt.hashSync(key, salt);
   }
 
   private generateId(): string {


### PR DESCRIPTION
Potential fix for [https://github.com/Giftedx/chatterbot/security/code-scanning/10](https://github.com/Giftedx/chatterbot/security/code-scanning/10)

To fix the problem, replace the use of a fast hash function (SHA-256) for hashing API keys with a slow, computationally expensive password hashing function. The best way to do this in Node.js/TypeScript is to use the `bcrypt` library, which is widely used and well-supported. Specifically, update the `hashApiKey` method to use `bcrypt.hashSync` (or the async version if desired), and ensure that the salt is generated securely. Since the rest of the code expects a synchronous hash, use `hashSync` for minimal disruption. Add the required import for `bcrypt` at the top of the file. No other changes to functionality are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
